### PR TITLE
test: remove global viper data race in cmd tests

### DIFF
--- a/cmd/scan_integration_test.go
+++ b/cmd/scan_integration_test.go
@@ -17,8 +17,6 @@ func TestScanCmd_Integration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	setupTestConfig(t)
-
 	// This would be a full integration test that requires:
 	// 1. A running Docker daemon
 	// 2. Test containers

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -114,16 +114,6 @@ func (m *MockLLMClient) ChatCompletion(_ context.Context, _ []llm.ChatMessage, _
 	}, m.analyzeError
 }
 
-func setupTestConfig(_ *testing.T) {
-	viper.Reset()
-	viper.Set("docker.socket", "")
-	viper.Set("llm.base_url", "http://mock-api")
-	viper.Set("llm.api_key", "mock-key")
-	viper.Set("llm.model", "mock-model")
-	viper.Set("llm.max_tokens", 4000)
-	viper.Set("state.file", "test-state.json")
-}
-
 func TestScanCmd_Flags(t *testing.T) {
 	cmd := scanCmd
 
@@ -145,8 +135,6 @@ func TestScanCmd_Flags(t *testing.T) {
 
 func TestScanCmd_DryRun(t *testing.T) {
 	t.Parallel()
-
-	setupTestConfig(t)
 
 	// Create mock containers
 	containers := []docker.Container{
@@ -201,8 +189,6 @@ func TestScanCmd_DryRun(t *testing.T) {
 }
 
 func TestScanCmd_WithFilter(t *testing.T) {
-	setupTestConfig(t)
-
 	// Create mock containers
 	containers := []docker.Container{
 		{
@@ -244,8 +230,6 @@ func TestScanCmd_WithFilter(t *testing.T) {
 }
 
 func TestScanCmd_LookbackOption(t *testing.T) {
-	setupTestConfig(t)
-
 	// Test lookback parsing
 	tests := []struct {
 		input    string
@@ -345,8 +329,6 @@ func TestScanCmd_ConfigValidation(t *testing.T) {
 }
 
 func TestScanCmd_ErrorHandling(t *testing.T) {
-	setupTestConfig(t)
-
 	tests := []struct {
 		name       string
 		setupMocks func() (*MockDockerClient, *MockLLMClient)
@@ -440,8 +422,6 @@ func TestScanCmd_OutputFormatting(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			setupTestConfig(t)
 
 			// Capture output
 			var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- Fixes an intermittent `go test -race` failure in the `cmd` package that was blocking unrelated PRs (e.g. #40, a trivial Renovate digest bump).
- `TestScanCmd_DryRun` and `TestScanCmd_OutputFormatting` both call `t.Parallel()` and both called `setupTestConfig`, which mutated the **global** viper singleton (`viper.Reset()`/`viper.Set(...)`). Go resumes all `t.Parallel()` tests together, so the concurrent `viper.Reset()` calls raced under `-race` — nondeterministically, which is why some PRs passed and others (like #40) didn't.
- All six `setupTestConfig` call sites turned out to be dead code — none of them read the config back (they use mocks, `newTestScanConfig()`, or `time.ParseDuration`). Removing the helper and its callers eliminates the only global-viper mutation reachable from a parallel test, so the affected tests stay parallel and the race is gone for good (not just silenced).
- `TestScanCmd_ConfigValidation` (the one test that genuinely needs global viper via `config.LoadFromViper()`) is untouched — it was already non-parallel and safe.

## Test plan
- [x] `go build ./...`
- [x] `CGO_ENABLED=1 go test -race -run 'TestScanCmd_DryRun|TestScanCmd_OutputFormatting' -count=20 ./cmd/` — no race across 20 reps (fails intermittently on unmodified `main`, confirmed via a side-by-side worktree comparison)
- [x] `CGO_ENABLED=1 go test -race -coverprofile=coverage.out -covermode=atomic ./...` — all packages pass, `cmd` at 60.4% coverage (unchanged)
- [x] `./scripts/check-coverage.sh coverage.out 80` — per-file 80% gate passes
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues